### PR TITLE
Update Preprocessor links in Introduction_to_Ray_AI_Runtime.ipynb

### DIFF
--- a/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
+++ b/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
@@ -368,7 +368,7 @@
    "source": [
     "**Coding exercise**\n",
     "\n",
-    "Ray AIR provides several [preprocessors out of the box](https://docs.ray.io/en/latest/data/preprocessors.html#types-of-preprocessors) and also supports the implementation of [custom preprocessors](https://docs.ray.io/en/latest/data/preprocessors.html#implementing-custom-preprocessors). Later on, you can compare model performance between the given preprocessor and your custom configuration.\n",
+    "Ray provides several [preprocessors out of the box](https://docs.ray.io/en/latest/data/preprocessors.html#types-of-preprocessors) and also supports the implementation of [custom preprocessors](https://docs.ray.io/en/latest/data/preprocessors.html#implementing-custom-preprocessors). Later on, you can compare model performance between the given preprocessor and your custom configuration.\n",
     "\n",
     "Select a [built-in](https://docs.ray.io/en/latest/data/preprocessors.html#built-in-preprocessors) `Preprocessor` and use `fit_transform()` to [apply it](https://docs.ray.io/en/latest/data/api/preprocessor.html#fit-transform-apis) to the dataset. Visualize the results (perhaps using the [integration with pandas](https://docs.ray.io/en/latest/data/api/input_output.html#ray.data.from_pandas) to generate a histogram view)\n",
     "\n",

--- a/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
+++ b/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
@@ -327,7 +327,7 @@
    "metadata": {},
    "source": [
     "### Preprocess the dataset\n",
-    "To transform our raw data into features, you will define a `Preprocessor`. [Ray AIR's `Preprocessor`](https://docs.ray.io/en/latest/data/api/preprocessor.html) captures the data transformation you apply and persists:\n",
+    "To transform our raw data into features, you will define a `Preprocessor`. [Ray `Preprocessor`](https://docs.ray.io/en/latest/data/api/preprocessor.html) captures the data transformation you apply and persists:\n",
     "\n",
     "- **During training**\n",
     "\n",

--- a/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
+++ b/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
@@ -472,7 +472,7 @@
     "- Within a checkpoint\n",
     "- On input batches for inference\n",
     "\n",
-    "AIR comes with a collection of built-in preprocessors, and you can also define your own with simple templates (see the [user guide](https://docs.ray.io/en/latest/data/preprocessors.html) for more information)."
+    "Ray comes with a collection of built-in preprocessors, and you can also define your own with simple templates (see the [user guide](https://docs.ray.io/en/latest/data/preprocessors.html) for more information)."
    ]
   },
   {

--- a/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
+++ b/Introductory_modules/Introduction_to_Ray_AI_Runtime.ipynb
@@ -327,7 +327,7 @@
    "metadata": {},
    "source": [
     "### Preprocess the dataset\n",
-    "To transform our raw data into features, you will define a `Preprocessor`. [Ray AIR's `Preprocessor`](https://docs.ray.io/en/latest/ray-air/package-ref.html#preprocessor) captures the data transformation you apply and persists:\n",
+    "To transform our raw data into features, you will define a `Preprocessor`. [Ray AIR's `Preprocessor`](https://docs.ray.io/en/latest/data/api/preprocessor.html) captures the data transformation you apply and persists:\n",
     "\n",
     "- **During training**\n",
     "\n",
@@ -368,9 +368,9 @@
    "source": [
     "**Coding exercise**\n",
     "\n",
-    "Ray AIR provides several [preprocessors out of the box](https://docs.ray.io/en/latest/ray-air/preprocessors.html#) and also supports the implementation of [custom preprocessors](https://docs.ray.io/en/latest/ray-air/preprocessors.html#implementing-custom-preprocessors). Later on, you can compare model performance between the given preprocessor and your custom configuration.\n",
+    "Ray AIR provides several [preprocessors out of the box](https://docs.ray.io/en/latest/data/preprocessors.html#types-of-preprocessors) and also supports the implementation of [custom preprocessors](https://docs.ray.io/en/latest/data/preprocessors.html#implementing-custom-preprocessors). Later on, you can compare model performance between the given preprocessor and your custom configuration.\n",
     "\n",
-    "Select a [built-in](https://docs.ray.io/en/latest/ray-air/preprocessors.html#types-of-preprocessors) `Preprocessor` and use `fit_transform()` to [apply it](https://docs.ray.io/en/latest/ray-air/package-ref.html#preprocessor) to the dataset. Visualize the results (perhaps using the [integration with pandas](https://docs.ray.io/en/latest/data/api/input_output.html#ray.data.from_pandas) to generate a histogram view)\n",
+    "Select a [built-in](https://docs.ray.io/en/latest/data/preprocessors.html#built-in-preprocessors) `Preprocessor` and use `fit_transform()` to [apply it](https://docs.ray.io/en/latest/data/api/preprocessor.html#fit-transform-apis) to the dataset. Visualize the results (perhaps using the [integration with pandas](https://docs.ray.io/en/latest/data/api/input_output.html#ray.data.from_pandas) to generate a histogram view)\n",
     "\n",
     "Note: You may want to create a sample dataset to transform, as the original data and preprocessor will be passed to the `Trainer` in the next step for transformation."
    ]
@@ -472,7 +472,7 @@
     "- Within a checkpoint\n",
     "- On input batches for inference\n",
     "\n",
-    "AIR comes with a collection of built-in preprocessors, and you can also define your own with simple templates (see the [user guide](https://docs.ray.io/en/latest/ray-air/preprocessors.html) for more information)."
+    "AIR comes with a collection of built-in preprocessors, and you can also define your own with simple templates (see the [user guide](https://docs.ray.io/en/latest/data/preprocessors.html) for more information)."
    ]
   },
   {


### PR DESCRIPTION
# Changes summary

Update some 404-not found hyper-links to current latest documentation of ray.data.preprocessor

# PR scope

* [ ] new notebook
* [x] improvements to the existing notebook
* [ ] bug fixes
* [ ] other

# Checklist

* [x] notebook is without outputs
* [x] empty cells are removed
* [x] code is formatted with [black](https://github.com/psf/black)
* [x] imports are sorted
* [ ] if new notebook is added, README is updated
