### PR TITLE
Fix Quickstart_with_Ray_AIR_Colab.ipynb import error

### DIFF
--- a/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb
+++ b/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U ray==2.3.0 xgboost_ray==0.1.15"
+    "! pip install -U ray==2.3.0 xgboost_ray==0.1.18"
    ]
   },
   {


### PR DESCRIPTION
Update package xgboost-ray install version to 0.1.18 to fix import error

# Changes summary

*Fixes #100*

*install xgboost-ray==0.1.18 instead of 0.1.15*

# PR scope

* [ ] new notebook
* [x] improvements to the existing notebook
* [x] bug fixes
* [ ] other

# Checklist
N/A
* [ ] notebook is without outputs
* [ ] empty cells are removed
* [ ] code is formatted with [black](https://github.com/psf/black)
* [ ] imports are sorted
* [ ] if new notebook is added, README is updated
