### PR TITLE
Remove broken image url

### DIFF
--- a/Ray_Core/tasks_helper_utils.py
+++ b/Ray_Core/tasks_helper_utils.py
@@ -67,7 +67,6 @@ URLS = [
     "https://images.pexels.com/photos/116675/pexels-photo-116675.jpeg",
     "https://images.pexels.com/photos/3586966/pexels-photo-3586966.jpeg",
     "https://images.pexels.com/photos/313782/pexels-photo-313782.jpeg",
-    "https://www.nasa.gov/centers/stennis/images/content/702979main_SSC-2012-01487.jpg",
     "https://live.staticflickr.com/2443/3984080835_71b0426844_b.jpg",
     "https://www.aero.jaxa.jp/eng/facilities/aeroengine/images/th_aeroengine05.jpg",
     "https://images.pexels.com/photos/370717/pexels-photo-370717.jpeg",


### PR DESCRIPTION
Remove url pointing to a 404 url

# Changes summary

*Fixes #ISSUE_NUMBER*
https://github.com/ray-project/ray-educational-materials/issues/111

*Summary of changes in this PR*
Remove a broken image url in the list.

The broken image url can lead to errors in the materials. E.g.
Running [this cell](https://github.com/ray-project/ray-educational-materials/blob/ea1a33c726e8728d80547db21be63263919810d6/Ray_Core/Ray_Core_1_Remote_Functions.ipynb?short_path=a3184ba#L712-L728) will get:
```
UnidentifiedImageError: cannot identify image file '**/ray-educational-materials/Ray_Core/task_images/stennis.jpg'
```

(image count referred `Let's download 100 large images` is not updated, as the # of images is 101 even after the removal)

# PR scope
* [ ] new notebook
* [ ] improvements to the existing notebook
* [x] bug fixes
* [ ] other

# Checklist
* [ ] notebook is without outputs
* [ ] empty cells are removed
* [ ] code is formatted with [black](https://github.com/psf/black)
* [ ] imports are sorted
* [ ] if new notebook is added, README is updated
